### PR TITLE
Add unique symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const re = parse('!re /fo./g', { customTags: [regexp] })
 
 - `regexp` (`!re`) - [RegExp] values,
   using their default `/foo/flags` string representation.
-- `symbol` (`!symbol`) - [Shared Symbols], i.e. ones created with `Symbol.for()`
+- `sharedSymbol` (`!symbol/shared`) - [Shared Symbols], i.e. ones created with `Symbol.for()`
 
 [RegExp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions
 [Shared Symbols]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#shared_symbols_in_the_global_symbol_registry

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ const re = parse('!re /fo./g', { customTags: [regexp] })
 - `regexp` (`!re`) - [RegExp] values,
   using their default `/foo/flags` string representation.
 - `sharedSymbol` (`!symbol/shared`) - [Shared Symbols], i.e. ones created with `Symbol.for()`
+- `symbol` (`!symbol`) - [Unique Symbols]
 
 [RegExp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions
 [Shared Symbols]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#shared_symbols_in_the_global_symbol_registry
+[Unique Symbols]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
 
 ## Customising Tag Names
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { regexp } from './regexp.js'
-export { sharedSymbol } from './symbol.js'
+export { sharedSymbol, symbol } from './symbol.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { regexp } from './regexp.js'
-export { symbol } from './symbol.js'
+export { sharedSymbol } from './symbol.js'

--- a/src/symbol.test.ts
+++ b/src/symbol.test.ts
@@ -1,11 +1,11 @@
 import { test } from 'tap'
-import { parse, stringify } from 'yaml'
+import { Document, type Scalar, parse, stringify } from 'yaml'
 
-import { sharedSymbol } from '.'
+import { sharedSymbol, symbol } from '.'
 
-test('parse', t => {
+test('parse shared', t => {
   const res: symbol = parse(`!symbol/shared foo`, {
-    customTags: [sharedSymbol]
+    customTags: [sharedSymbol, symbol]
   })
   t.type(res, 'symbol')
   t.same(Symbol.keyFor(res), 'foo')
@@ -13,16 +13,44 @@ test('parse', t => {
 })
 
 test('stringify shared', t => {
-  const res = stringify(Symbol.for('some\nsymbol'), {
-    customTags: [sharedSymbol]
+  const doc = new Document<Scalar, false>(Symbol.for('some\nsymbol'), {
+    customTags: [sharedSymbol, symbol]
   })
-  t.equal(res, '!symbol/shared |-\nsome\nsymbol\n')
+  t.equal(doc.toString(), '!symbol/shared |-\nsome\nsymbol\n')
+
+  doc.contents.value = Symbol('foo')
+  t.throws(() => doc.toString(), { name: 'TypeError' })
+
+  doc.contents.value = 42
+  t.throws(() => doc.toString(), { name: 'TypeError' })
+
+  t.throws(() =>
+    stringify(Symbol('some\nsymbol'), { customTags: [sharedSymbol] })
+  )
+
+  t.end()
+})
+
+test('parse private', t => {
+  const res: symbol = parse(`!symbol foo`, {
+    customTags: [sharedSymbol, symbol]
+  })
+  t.type(res, 'symbol')
+  t.notOk(Symbol.keyFor(res))
   t.end()
 })
 
 test('stringify private', t => {
-  t.throws(() =>
-    stringify(Symbol('some\nsymbol'), { customTags: [sharedSymbol] })
-  )
+  const doc = new Document<Scalar, false>(Symbol('some\nsymbol'), {
+    customTags: [sharedSymbol, symbol]
+  })
+  t.equal(doc.toString(), '!symbol |-\nsome\nsymbol\n')
+
+  doc.contents.value = Symbol.for('foo')
+  t.equal(doc.toString(), '!symbol foo\n')
+
+  doc.contents.value = 'foo'
+  t.throws(() => doc.toString(), { name: 'TypeError' })
+
   t.end()
 })

--- a/src/symbol.test.ts
+++ b/src/symbol.test.ts
@@ -1,22 +1,28 @@
 import { test } from 'tap'
 import { parse, stringify } from 'yaml'
 
-import { symbol } from '.'
+import { sharedSymbol } from '.'
 
 test('parse', t => {
-  const res: symbol = parse(`!symbol foo`, { customTags: [symbol] })
+  const res: symbol = parse(`!symbol/shared foo`, {
+    customTags: [sharedSymbol]
+  })
   t.type(res, 'symbol')
   t.same(Symbol.keyFor(res), 'foo')
   t.end()
 })
 
 test('stringify shared', t => {
-  const res = stringify(Symbol.for('some\nsymbol'), { customTags: [symbol] })
-  t.equal(res, '!symbol |-\nsome\nsymbol\n')
+  const res = stringify(Symbol.for('some\nsymbol'), {
+    customTags: [sharedSymbol]
+  })
+  t.equal(res, '!symbol/shared |-\nsome\nsymbol\n')
   t.end()
 })
 
 test('stringify private', t => {
-  t.throws(() => stringify(Symbol('some\nsymbol'), { customTags: [symbol] }))
+  t.throws(() =>
+    stringify(Symbol('some\nsymbol'), { customTags: [sharedSymbol] })
+  )
   t.end()
 })

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -2,12 +2,28 @@ import type { Scalar, ScalarTag } from 'yaml'
 import { StringifyContext, stringifyString } from 'yaml/util'
 
 export const sharedSymbol = {
-  identify: value => value?.constructor === Symbol,
+  identify: value =>
+    value?.constructor === Symbol && typeof Symbol.keyFor(value) === 'string',
   tag: '!symbol/shared',
   resolve: str => Symbol.for(str),
   stringify(item: Scalar, ctx: StringifyContext, onComment, onChompKeep) {
     const key = Symbol.keyFor(item.value as symbol)
-    if (key === undefined) throw new Error('Only shared symbols are supported')
+    if (key === undefined) {
+      throw new TypeError('Only shared symbols are supported')
+    }
     return stringifyString({ value: key }, ctx, onComment, onChompKeep)
+  }
+} satisfies ScalarTag
+
+export const symbol = {
+  identify: value =>
+    value?.constructor === Symbol && Symbol.keyFor(value) === undefined,
+  tag: '!symbol',
+  resolve: str => Symbol(str),
+  stringify(item: Scalar, ctx: StringifyContext, onComment, onChompKeep) {
+    const sym = item.value
+    if (typeof sym !== 'symbol') throw new TypeError(`${sym} is not a symbol`)
+    const value = String(sym).replace(/^Symbol\(|\)$/g, '')
+    return stringifyString({ value }, ctx, onComment, onChompKeep)
   }
 } satisfies ScalarTag

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,9 +1,9 @@
 import type { Scalar, ScalarTag } from 'yaml'
 import { StringifyContext, stringifyString } from 'yaml/util'
 
-export const symbol = {
+export const sharedSymbol = {
   identify: value => value?.constructor === Symbol,
-  tag: '!symbol',
+  tag: '!symbol/shared',
   resolve: str => Symbol.for(str),
   stringify(item: Scalar, ctx: StringifyContext, onComment, onChompKeep) {
     const key = Symbol.keyFor(item.value as symbol)


### PR DESCRIPTION
As discussed here with @isaacs: https://github.com/eemeli/yaml-types/commit/450e600607607e268386a44fd2d19e33f9ff1a8f#r110049827

The tag for shared symbols is renamed as `!symbol/shared`, and a new `!symbol` is added for unique symbols.